### PR TITLE
Enable to extract renamed files

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function gitDiffArchive(commit, oldCommit, options) {
     if (commit2 == null) {
       diff = commit1;
       } else {
-        diff = `${commit1} ${commit2}`;
+        diff = `${commit2} ${commit1}`;
       }
     }
 

--- a/test/git-diff-archive.js
+++ b/test/git-diff-archive.js
@@ -12,11 +12,13 @@ const ID1 = "b148b54";
 const ID2 = "acd6e6d";
 const EMPTY_ID1 = "f74c8e2";
 const EMPTY_ID2 = "574443a";
+const RENAME_ID1 = "3779749";
+const RENAME_ID2 = "67bf532";
 const OUTPUT_DIR = `${__dirname}/tmp`;
 const OUTPUT_PATH = `${OUTPUT_DIR}/output.zip`;
 
 describe("git-diff-archive", () => {
-  after(() => {
+  afterEach(() => {
     rimraf.sync(OUTPUT_DIR);
   });
 
@@ -46,28 +48,49 @@ describe("git-diff-archive", () => {
     });
   });
 
-  it("should be created diff zip", (done) => {
-    gitDiffArchive(ID1, ID2, {output: OUTPUT_PATH})
-      .then((res) => {
-        const stat = fs.statSync(OUTPUT_PATH);
-        assert(stat.isFile() === true);
+  describe("should be created diff zip", () => {
+    it("add / modify", (done) => {
+      gitDiffArchive(ID1, ID2, {output: OUTPUT_PATH})
+        .then((res) => {
+          const stat = fs.statSync(OUTPUT_PATH);
+          assert(stat.isFile() === true);
 
-        fs.createReadStream(OUTPUT_PATH)
-          .pipe(unzip.Extract(({path: OUTPUT_DIR})))
-          .on("close", () => {
-            const files = glob.sync(`${OUTPUT_DIR}/**/*`, {nodir: true, dot: true});
-            assert(files.length === 6);
-            assert(files.indexOf(OUTPUT_PATH) > -1);
-            assert(files.indexOf(`${OUTPUT_DIR}/git-diff-archive/.eslintrc`) > -1);
-            assert(files.indexOf(`${OUTPUT_DIR}/git-diff-archive/LICENSE`) > -1);
-            assert(files.indexOf(`${OUTPUT_DIR}/git-diff-archive/README.md`) > -1);
-            assert(files.indexOf(`${OUTPUT_DIR}/git-diff-archive/bin/usage.txt`) > -1);
-            assert(files.indexOf(`${OUTPUT_DIR}/git-diff-archive/package.json`) > -1);
-            assert(res.exclude.length === 1);
-            assert(res.exclude.indexOf("bin/cmd.js") > -1);
-            done();
-          });
-      });
+          fs.createReadStream(OUTPUT_PATH)
+            .pipe(unzip.Extract(({path: OUTPUT_DIR})))
+            .on("close", () => {
+              const files = glob.sync(`${OUTPUT_DIR}/**/*`, {nodir: true, dot: true});
+              assert(files.length === 6);
+              assert(files.indexOf(OUTPUT_PATH) > -1);
+              assert(files.indexOf(`${OUTPUT_DIR}/git-diff-archive/.eslintrc`) > -1);
+              assert(files.indexOf(`${OUTPUT_DIR}/git-diff-archive/LICENSE`) > -1);
+              assert(files.indexOf(`${OUTPUT_DIR}/git-diff-archive/README.md`) > -1);
+              assert(files.indexOf(`${OUTPUT_DIR}/git-diff-archive/bin/usage.txt`) > -1);
+              assert(files.indexOf(`${OUTPUT_DIR}/git-diff-archive/package.json`) > -1);
+              assert(res.exclude.length === 1);
+              assert(res.exclude.indexOf("bin/cmd.js") > -1);
+              done();
+            });
+        });
+    });
+
+    it("rename", (done) => {
+      gitDiffArchive(RENAME_ID1, RENAME_ID2, {output: OUTPUT_PATH})
+        .then((res) => {
+          const stat = fs.statSync(OUTPUT_PATH);
+          assert(stat.isFile() === true);
+
+          fs.createReadStream(OUTPUT_PATH)
+            .pipe(unzip.Extract(({path: OUTPUT_DIR})))
+            .on("close", () => {
+              const files = glob.sync(`${OUTPUT_DIR}/**/*`, {nodir: true, dot: true});
+              assert(files.length === 3);
+              assert(files.indexOf(OUTPUT_PATH) > -1);
+              assert(files.indexOf(`${OUTPUT_DIR}/git-diff-archive/bin/git_diff_archive`) > -1);
+              assert(files.indexOf(`${OUTPUT_DIR}/git-diff-archive/package.json`) > -1);
+              done();
+            });
+        });
+    });
   });
 
   describe("should arguments are passed", () => {
@@ -78,7 +101,7 @@ describe("git-diff-archive", () => {
         diffFilter: "AMCRD"
       })
       .then((res) => {
-        assert(res.cmd === `git diff --name-only --diff-filter=AMCRD ${ID1} ${ID2}`);
+        assert(res.cmd === `git diff --name-only --diff-filter=AMCRD ${ID2} ${ID1}`);
         assert(res.output === OUTPUT_PATH);
         assert(res.prefix === "files");
         done();


### PR DESCRIPTION
The current commit hash order that passed to diff command will produce file names before renamed.

For example, we would expect gda to extract `bin/git_diff_archive` in [this diff](67bf532...3779749) since it renamed from `bin/cmd.js`. But current behavior doesn't. It looks try to extract old name.

I just swapped commit hashes in the diff command and added a test case to confirm it.