### PR TITLE
Add `--base` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Options:
   -f, --format (zip|tar)     Specified in the `zip` or `tar` the format of the archive.
   -o, --output               Output destination path of the archive. (Use `PATH_SYNTAX`)
   -p, --prefix               Prepended to the filenames in the archive. (Use `PATH_SYNTAX`)
+  -b, --base                 Rebase the file paths in the archive. Specified path will be the root.
   -F, --diff-filter          `git diff --diff-filter` and a similar designation.
       (A|C|D|M|R|T|U|X|B|*)
 
@@ -86,6 +87,7 @@ Defaults:
   --format      = zip
   --prefix      = {dirname}
   --output      = {dirname}-{datetime}.{format}
+  --base        = .
   --diff-filter = ACDMRTUXB
 
 

--- a/bin/gda
+++ b/bin/gda
@@ -23,6 +23,7 @@ const argv = minimist(process.argv.slice(2), {
     f: "format",
     o: "output",
     p: "prefix",
+    b: "base",
     n: "dry-run",
     v: "verbose",
     V: "version",
@@ -33,6 +34,7 @@ const argv = minimist(process.argv.slice(2), {
     "format",
     "output",
     "prefix",
+    "base",
     "_"
   ],
   boolean: [
@@ -95,6 +97,7 @@ if (argv.help) {
   if (argv.format) options.format = argv.format;
   if (argv.output) options.output = argv.output;
   if (argv.prefix) options.prefix = argv.prefix;
+  if (argv.base) options.base = argv.base;
   if (argv["dry-run"]) options.dryRun = true;
   if (argv.verbose) options.verbose = true;
 
@@ -106,6 +109,7 @@ if (argv.help) {
         {"Git Command"    : res.cmd},
         {"Output"         : `${res.output} (${prettyBytes(res.bytes)})`},
         {"Prefix"         : res.prefix},
+        {"Base"           : res.base},
         {"Files"          : res.files.join("\n")},
         {"Exclude"        : res.exclude.join("\n")}
       );

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -20,6 +20,7 @@ Options:
   -f, --format (zip|tar)     Specified in the `zip` or `tar` the format of the archive.
   -o, --output               Output destination path of the archive. (Use `PATH_SYNTAX`)
   -p, --prefix               Prepended to the filenames in the archive. (Use `PATH_SYNTAX`)
+  -b, --base                 Rebase the file paths in the archive. Specified path will be the root.
   -F, --diff-filter          `git diff --diff-filter` and a similar designation.
       (A|C|D|M|R|T|U|X|B|*)
 
@@ -41,6 +42,7 @@ Defaults:
   --format      = zip
   --prefix      = {dirname}
   --output      = {dirname}-{datetime}.{format}
+  --base        = .
   --diff-filter = ACDMRTUXB
 
 

--- a/test/git-diff-archive.js
+++ b/test/git-diff-archive.js
@@ -91,6 +91,25 @@ describe("git-diff-archive", () => {
             });
         });
     });
+
+    it("rebase root", (done) => {
+      gitDiffArchive(ID1, ID2, {output: OUTPUT_PATH, base: 'bin'})
+        .then((res) => {
+          const stat = fs.statSync(OUTPUT_PATH);
+          assert(stat.isFile() === true);
+          assert(res.base === 'bin');
+
+          fs.createReadStream(OUTPUT_PATH)
+            .pipe(unzip.Extract(({path: OUTPUT_DIR})))
+            .on("close", () => {
+              const files = glob.sync(`${OUTPUT_DIR}/**/*`, {nodir: true, dot: true});
+              assert(files.length === 2);
+              assert(files.indexOf(OUTPUT_PATH) > -1);
+              assert(files.indexOf(`${OUTPUT_DIR}/git-diff-archive/usage.txt`) > -1);
+              done();
+            });
+        });
+    });
   });
 
   describe("should arguments are passed", () => {


### PR DESCRIPTION
## Issue

Sometimes I would like to rebase the archived file paths. For examples, on the following file structures:

```
├── dist # output files of src directry
├── src # source files which are needed to compile
│   └── ...
...
```

I want to extract diff files in the `dist` directry by using gda but there are two issues.

1. It may include the files out of `dist` directry.
2. The output archive always has `dist` directory which I (and probably others) does not need.

1 is not critical problem since we can only commit under `dist` before executing gda, but 2 is a little big problem for me. Currently I need to unzip and change file structures, then zip them again.

Then, I've added `--base` option to solve these problems in this PR.

## `--base` option

The `--base` (shorthand `-b`) option rebases the internal file paths in the archive.
For example, if the user specify `--base foo/bar`, gda will only pick the files under `foo/bar/` directry and treat it as the root directry. Files out of base directory are excluded from the archive.

Example:

```sh
$ git diff --name-only HEAD HEAD^
README.md
bin/gda
bin/usage.txt
index.js
test/git-diff-archive.js

$ gda -b bin HEAD HEAD^
 -------------------------------------------------------------------------------
   Processing Time  |  68 ms
 -------------------+-----------------------------------------------------------
   Git Command      |  git diff --name-only --diff-filter=ACDMRTUXB HEAD^ HEAD
 -------------------+-----------------------------------------------------------
   Output           |  git-diff-archive-20180601123520.zip (2.21 kB)
 -------------------+-----------------------------------------------------------
   Prefix           |  git-diff-archive
 -------------------+-----------------------------------------------------------
   Base             |  bin
 -------------------+-----------------------------------------------------------
   Files            |  gda
                    |  usage.txt
 -------------------+-----------------------------------------------------------
   Exclude          |
 -------------------------------------------------------------------------------

$ unzip git-diff-archive-20180601123520.zip
Archive:  git-diff-archive-20180601123520.zip
  inflating: git-diff-archive/gda
  inflating: git-diff-archive/usage.txt

$ ls git-diff-archive
gda		usage.txt
```