### PR TITLE
feat: no-prefix

### DIFF
--- a/bin/gda
+++ b/bin/gda
@@ -23,6 +23,7 @@ const argv = minimist(process.argv.slice(2), {
     f: "format",
     o: "output",
     p: "prefix",
+    P: "no-prefix",
     b: "base",
     n: "dry-run",
     v: "verbose",
@@ -39,6 +40,7 @@ const argv = minimist(process.argv.slice(2), {
   ],
   boolean: [
     "dry-run",
+    "no-prefix",
     "verbose",
     "help",
     "version"
@@ -97,6 +99,7 @@ if (argv.help) {
   if (argv.format) options.format = argv.format;
   if (argv.output) options.output = argv.output;
   if (argv.prefix) options.prefix = argv.prefix;
+  if (argv["no-prefix"]) options.noPrefix = true;
   if (argv.base) options.base = argv.base;
   if (argv["dry-run"]) options.dryRun = true;
   if (argv.verbose) options.verbose = true;

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -19,7 +19,8 @@ Options:
   -n, --dry-run              Don't actually create the files. just show what would be done.
   -f, --format (zip|tar)     Specified in the `zip` or `tar` the format of the archive.
   -o, --output               Output destination path of the archive. (Use `PATH_SYNTAX`)
-  -p, --prefix               Prepended to the filenames in the archive. (Use `PATH_SYNTAX`)
+  -p, --prefix               Prefixed to the filenames in the archive. (Use `PATH_SYNTAX`) [default: <current-dir>]
+  -P, --no-prefix            Prefix nothing to the filenames in the archive.
   -b, --base                 Rebase the file paths in the archive. Specified path will be the root.
   -F, --diff-filter          `git diff --diff-filter` and a similar designation.
       (A|C|D|M|R|T|U|X|B|*)

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function gitDiffArchive(commit, oldCommit, options) {
     const files = rebaseFiles(filterFiles(lines, true), params.base);
     const exclude = rebaseFiles(filterFiles(lines, false), params.base);
     params.output = createPath(params.output, params.format);
-    params.prefix = createPath(params.prefix, params.format);
+    params.prefix = !params.noPrefix && createPath(params.prefix, params.format);
 
     const spinner = new Spinner("processing... %s");
     spinner.setSpinnerString(spinnerStringID);


### PR DESCRIPTION
Adds a `--no-prefix` `-P` option to prefix nothing to the filenames in the archive.

Fixes #16